### PR TITLE
Fixed warnings and compile issues on Mac.

### DIFF
--- a/bchlib/bch.c
+++ b/bchlib/bch.c
@@ -79,7 +79,12 @@
 #else
 
 # define _BSD_SOURCE
-# include <endian.h>
+# if defined(__APPLE__)
+#   include <libkern/OSByteOrder.h>
+#   define htobe32(x) OSSwapHostToBigInt32(x)
+# else
+#   include <endian.h>
+# endif
 # include <errno.h>
 # include <stdint.h>
 # include <stdio.h>

--- a/bchlib/bchlib.c
+++ b/bchlib/bchlib.c
@@ -169,7 +169,7 @@ Bch_correct(BchObject *self, PyObject *args, PyObject *kwds)
 
 		Py_INCREF(po_syn);
 		unsigned int syn[self->bch->t];
-		for (int i = 0; i < self->bch->t*2; i++) {
+		for (unsigned int i = 0; i < self->bch->t*2; i++) {
 			PyObject *value = PySequence_GetItem(po_syn, i);
 			Py_INCREF(value);
 			long ltmp = PyLong_AsLong(value);
@@ -241,7 +241,7 @@ Bch_calc_even_syndrome(BchObject *self, PyObject *args, PyObject *kwds)
 	PyObject *value = NULL;
 	unsigned int *syn = NULL;
 	long tmp;
-	int i;
+	unsigned int i;
 
 	if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", kwlist,
 			&po_syn))
@@ -295,7 +295,7 @@ Bch_getattr(BchObject *self, PyObject *name)
 {
 	PyObject *value;
 	PyObject *result = NULL;
-	int i;
+	unsigned int i;
 
 	Py_INCREF(name);
 	const char *cname = PyUnicode_AsUTF8(name);


### PR DESCRIPTION
1. Fixed warnings about signed/unsigned compare.
2.  Made compatible with MacOS.
