### PR TITLE
Fix compatibility with Python 3.11

### DIFF
--- a/src/bchlib.c
+++ b/src/bchlib.c
@@ -31,6 +31,12 @@
 # define alloca(size) _alloca(size)
 #endif
 
+#if PY_VERSION_HEX < 0x030900A4 && !defined(Py_SET_SIZE)
+static inline void _Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size)
+{ ob->ob_size = size; }
+#define Py_SET_SIZE(ob, size) _Py_SET_SIZE((PyObject*)(ob), size)
+#endif
+
 
 typedef struct {
 	PyObject_HEAD
@@ -141,7 +147,7 @@ BCH_encode(BCHObject *self, PyObject *args, PyObject *kwds)
 	} else {
 		memset(result_ecc->ob_bytes, 0, ecc_bytes);
 	}
-	Py_SIZE(result_ecc) = ecc_bytes;
+	Py_SET_SIZE(result_ecc, ecc_bytes);
 	result_ecc->ob_alloc = ecc_bytes;
 #if PY_MAJOR_VERSION >= 3
 	result_ecc->ob_start = result_ecc->ob_bytes;
@@ -223,7 +229,7 @@ BCH_decode(BCHObject *self, PyObject *args, PyObject *kwds)
 	} else {
 		memcpy(result_data->ob_bytes, data.buf, data.len);
 	}
-	Py_SIZE(result_data) = data.len;
+	Py_SET_SIZE(result_data, data.len);
 	result_data->ob_alloc = data.len;
 #if PY_MAJOR_VERSION >= 3
 	result_data->ob_start = result_data->ob_bytes;
@@ -231,7 +237,7 @@ BCH_decode(BCHObject *self, PyObject *args, PyObject *kwds)
 	result_data->ob_exports = 0;
 
 	memcpy(result_ecc->ob_bytes, ecc.buf, ecc.len);
-	Py_SIZE(result_ecc) = ecc.len;
+	Py_SET_SIZE(result_ecc, ecc.len);
 	result_ecc->ob_alloc = ecc.len;
 #if PY_MAJOR_VERSION >= 3
 	result_ecc->ob_start = result_ecc->ob_bytes;
@@ -418,7 +424,7 @@ BCH_decode_syndromes(BCHObject *self, PyObject *args, PyObject *kwds)
 	} else {
 		memcpy(result_data->ob_bytes, data.buf, data.len);
 	}
-	Py_SIZE(result_data) = data.len;
+	Py_SET_SIZE(result_data, data.len);
 	result_data->ob_alloc = data.len;
 #if PY_MAJOR_VERSION >= 3
 	result_data->ob_start = result_data->ob_bytes;


### PR DESCRIPTION
Use a static inline function and a macro for compatibility with Python < 3.9 as well as Python >= 3.9.
The Python API after 3.9a4 supports the `Py_SET_SIZE` function, before this version setting `Py_SIZE` was the way to go.

This is inspired by the solution in this pull request to the `rdiff-backup` project.
https://github.com/rdiff-backup/rdiff-backup/pull/655/files

This change has been tested on Arch Linux with python 3.8.17, 3.9.17, 3.10.12 and 3.11.4 (installation and unittest).