### PR TITLE
dev(narugo): downgrade to artifacts@v3, fix issue #38

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
-          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          name: artifact
           path: ./wheelhouse/*.whl
 
   build_sdist:
@@ -43,8 +43,9 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
+          name: artifact
           path: dist/*.tar.gz
 
   upload_pypi:
@@ -55,7 +56,7 @@ jobs:
       id-token: write
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
Fix issue #38 by downgrading the artifact-upload/download action.

when using v4, the same name will cause conflict on github action runtime. so if you insist on using v4 u will have to download all the artifacts one by one.

so as a simpler solution, i downgrade it to v3 for quick fix.

